### PR TITLE
Clear and fix events movment on calendar

### DIFF
--- a/src/module/event/presentation/component/details/meta.details.component.ts
+++ b/src/module/event/presentation/component/details/meta.details.component.ts
@@ -135,7 +135,6 @@ export class MetaDetailsComponent implements OnChanges {
 					});
 					return;
 				case 'status':
-					console.log(historyItem.value);
 					this.chronologyList.push({
 						iso: null,
 						labelTranslateKey: 'event.keyword.capitalize.statusChangedTo',

--- a/src/module/order/presentation/component/list/layout/list-of-card-collection-by-date/list-of-card-collection-by-date.layout.ts
+++ b/src/module/order/presentation/component/list/layout/list-of-card-collection-by-date/list-of-card-collection-by-date.layout.ts
@@ -82,8 +82,6 @@ export class ListOfCardCollectionByDateLayout extends LayoutListComponent<IOrder
 
 	public ngOnChanges(changes: SimpleChanges & { tableState: SimpleChange }) {
 
-		console.log(changes)
-
 		if (changes.tableState?.currentValue) {
 			const {items} = changes.tableState.currentValue as { items: IOrderDto[] };
 			this.items = items.reduce((acc, item) => {
@@ -97,7 +95,6 @@ export class ListOfCardCollectionByDateLayout extends LayoutListComponent<IOrder
 				acc[dateKey] = dateGroup;
 				return acc;
 			}, {} as { [key: string]: { [key: string]: IOrderDto[] } });
-			console.log(this.items)
 		}
 		this.changeDetectorRef.detectChanges();
 

--- a/src/module/utility/presentation/component/input/price-and-currency.component.ts
+++ b/src/module/utility/presentation/component/input/price-and-currency.component.ts
@@ -113,18 +113,13 @@ export class PriceAndCurrencyComponent implements OnChanges {
 	public readonly translateService = inject(TranslateService);
 
 	public ngOnChanges(changes: SimpleChanges & { currencyList: SimpleChange }) {
-		console.log(changes)
 		if (changes.currencyList) {
 			this.updateValue(changes.currencyList.currentValue);
 		}
 
-		this.currencyControl.valueChanges.subscribe((currency) => {
-			console.log(currency)
-		});
 	}
 
 	private updateValue(currencies: { id: CurrencyCodeEnum; name: CurrencyCodeEnum; }[]): void {
-		console.log(this.currencyControl.value)
 		if (!this.currencyControl.value) {
 			this.currencyControl.setValue(currencies[0].id);
 		}

--- a/src/page/event/calendar-with-specialists/v2/component/main/calendar-with-specialist.widget.component.ts
+++ b/src/page/event/calendar-with-specialists/v2/component/main/calendar-with-specialist.widget.component.ts
@@ -744,20 +744,17 @@ export class CalendarWithSpecialistWidgetComponent extends Reactive implements O
 		targetBottom = targetBottom / this.calendarWithSpecialistLocaStateService.oneMinuteForPx;
 		targetBottom = targetBottom | 0;
 
-		const htmlElementInside = targetTop > sourceTop && targetBottom < sourceBottom;
-		if (htmlElementInside) {
-			return true;
+		switch (true) {
+			case targetTop > sourceTop && targetBottom < sourceBottom: // target is inside source
+			case targetTop <= sourceTop && sourceTop < targetBottom: // targetTop is inside source
+			case targetBottom >= sourceBottom && sourceBottom > targetTop: // targetBottom is inside source
+			case targetTop < sourceTop && targetBottom > sourceBottom: // target is outside source
+			case targetTop === sourceTop && targetBottom === sourceBottom: // target is equal to source
+				return true;
 		}
-		const htmlElementTop = targetTop > sourceTop && targetTop < sourceBottom;
-		if (htmlElementTop) {
-			return true;
-		}
-		const htmlElementBottom = targetBottom > sourceTop && targetBottom < sourceBottom;
-		if (htmlElementBottom) {
-			return true;
-		}
-		const htmlElementOutside = targetTop < sourceTop && targetBottom > sourceBottom;
-		return htmlElementOutside;
+
+		return false;
+
 
 	}
 

--- a/src/page/event/calendar-with-specialists/v2/component/schedule-element.calendar-with-specialist.widget.component.ts
+++ b/src/page/event/calendar-with-specialists/v2/component/schedule-element.calendar-with-specialist.widget.component.ts
@@ -114,8 +114,6 @@ export class ScheduleElementCalendarWithSpecialistWidgetComponent extends Reacti
 				this.takeUntil(),
 			).subscribe((scheduleElements: QueryList<ElementRef<HTMLDivElement>>) => {
 
-				console.log('scheduleElements', this.scrollInitialized, scheduleElements.first.nativeElement.offsetTop, this.calendarWithSpecialistLocaStateService.specialistCellHeightForPx);
-
 				if (this.scrollInitialized.isOn) {
 					return;
 				}

--- a/src/page/order/list/list.order.page.ts
+++ b/src/page/order/list/list.order.page.ts
@@ -67,7 +67,6 @@ export class ListOrderPage extends ListPage {
 	public readonly tableState$: Observable<ITableState<IOrderDto>> = this.store.select(OrderState.tableState)
 		.pipe(
 			tap((tableState) => {
-				console.log(tableState)
 				this.changeDetectorRef.detectChanges();
 			})
 		);


### PR DESCRIPTION
Перевіряє, чи розташований один HTML елемент (`target`) поруч з іншим (`source`) на основі їх координат. Використовується для визначення близькості подій у календарі, щоб відповідно коригувати їх відображення.