### PR TITLE
BOC-381 | [CPA - balance] Delete 'updated at' column because it's at almost case redundant.

### DIFF
--- a/src/tenant/balance/presentation/ui/component/list/table/table.list.component.ts
+++ b/src/tenant/balance/presentation/ui/component/list/table/table.list.component.ts
@@ -102,14 +102,14 @@ export class TableListComponent extends TableComponent<EBalance> {
 			sortable: true,
 			$$valueGetter: this.anyDateConvert,
 		},
-		{
-			name: this.translateService.instant('keyword.capitalize.updatedAt'),
-			prop: 'updatedAt',
-			minWidth: 240,
-			width: 240,
-			sortable: true,
-			$$valueGetter: this.anyDateConvert,
-		},
+		// {
+		// 	name: this.translateService.instant('keyword.capitalize.updatedAt'),
+		// 	prop: 'updatedAt',
+		// 	minWidth: 240,
+		// 	width: 240,
+		// 	sortable: true,
+		// 	$$valueGetter: this.anyDateConvert,
+		// },
 	]);
 
 	public readonly columnList = computed(() => {


### PR DESCRIPTION
https://beeoclock.atlassian.net/browse/BOC-381